### PR TITLE
Switch Reason bool to Js.boolean type

### DIFF
--- a/src/next.re
+++ b/src/next.re
@@ -3,10 +3,10 @@ module Link = {
   let make
       ::href=?
       ::_as=?
-      prefetch::(prefetch: option bool)=?
-      replace::(replace: option bool)=?
-      shallow::(shallow: option bool)=?
-      passHref::(passHref: option bool)=?
+      prefetch::(prefetch: option Js.boolean)=?
+      replace::(replace: option Js.boolean)=?
+      shallow::(shallow: option Js.boolean)=?
+      passHref::(passHref: option Js.boolean)=?
       children =>
     ReasonReact.wrapJsForReason
       reactClass::link

--- a/src/next.rei
+++ b/src/next.rei
@@ -3,10 +3,10 @@ module Link: {
   let make:
     href::'a? =>
     _as::'b? =>
-    prefetch::bool? =>
-    replace::bool? =>
-    shallow::bool? =>
-    passHref::bool? =>
+    prefetch::Js.boolean? =>
+    replace::Js.boolean? =>
+    shallow::Js.boolean? =>
+    passHref::Js.boolean? =>
     array ReasonReact.reactElement =>
     ReasonReact.component ReasonReact.stateless ReasonReact.noRetainedProps;
 };


### PR DESCRIPTION
While testing out `bs-next` I noticed a React PropType error as a result of passing a Reason bool to `next/Link`, which expects a JavaScript boolean:

<img width="674" alt="screen shot 2017-08-28 at 11 58 14 pm" src="https://user-images.githubusercontent.com/3142663/29803927-10518560-8c4d-11e7-9f04-884b065208c3.png">

<img width="675" alt="screen shot 2017-08-28 at 11 58 44 pm" src="https://user-images.githubusercontent.com/3142663/29803930-15ba13aa-8c4d-11e7-8404-d74271994d79.png">

This PR makes the change necessary to prevent this PropType error.

Usage:

```ocaml
<Link href="/" prefetch=(Js.Boolean.to_js_boolean true)> 
  <a>
    (ReasonReact.stringToElement "index")
  </a>
</Link>
```

cc @ulrikstrid 